### PR TITLE
Fix homepage URL

### DIFF
--- a/pub_grub.gemspec
+++ b/pub_grub.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{A version solver based on dart's PubGrub}
   spec.description   = %q{A version solver based on dart's PubGrub}
-  spec.homepage      = "https://github.com/jhawthorn/pubgrub"
+  spec.homepage      = "https://github.com/jhawthorn/pub_grub"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
Spotted while trying to access the home page on https://rubygems.org/gems/pub_grub.