### PR TITLE
Fix shadowing outer local variable warning

### DIFF
--- a/lib/pub_grub/partial_solution.rb
+++ b/lib/pub_grub/partial_solution.rb
@@ -35,8 +35,8 @@ module PubGrub
 
     def satisfier(term)
       assignment =
-        @assignments_by[term.package].bsearch do |assignment|
-          @cumulative_assignments[assignment].satisfies?(term)
+        @assignments_by[term.package].bsearch do |assignment_by|
+          @cumulative_assignments[assignment_by].satisfies?(term)
         end
 
       assignment || raise("#{term} unsatisfied")


### PR DESCRIPTION
Hi!

I notice a warning while working on a project uses pub_grub. This PR removes the warning.

```
lib/pub_grub/partial_solution.rb:38: warning: shadowing outer local variable - assignment
```

https://buildkite.com/matthewd/gel/builds/316#78bb8343-499d-4460-bb84-798bb5f297c0

Thank you!