### PR TITLE
Avoid default gems

### DIFF
--- a/lib/pub_grub.rb
+++ b/lib/pub_grub.rb
@@ -10,12 +10,22 @@ require 'pub_grub/solve_failure'
 require 'pub_grub/failure_writer'
 require 'pub_grub/version'
 
-require "logger"
-
 module PubGrub
   class << self
-    attr_accessor :logger
+    attr_writer :logger
+
+    def logger
+      @logger || default_logger
+    end
+
+    private
+
+    def default_logger
+      require "logger"
+
+      logger = ::Logger.new(STDERR)
+      logger.level = $DEBUG ? ::Logger::DEBUG : ::Logger::WARN
+      @logger = logger
+    end
   end
-  self.logger = Logger.new(STDERR)
-  self.logger.level = $DEBUG ? Logger::DEBUG : Logger::WARN
 end

--- a/lib/pub_grub/partial_solution.rb
+++ b/lib/pub_grub/partial_solution.rb
@@ -1,5 +1,4 @@
 require 'pub_grub/assignment'
-require 'set'
 
 module PubGrub
   class PartialSolution
@@ -44,7 +43,7 @@ module PubGrub
 
     # A list of unsatisfied terms
     def unsatisfied
-      @required.reject do |package|
+      @required.keys.reject do |package|
         @decisions.key?(package)
       end.map do |package|
         @terms[package]
@@ -96,7 +95,7 @@ module PubGrub
       @relation_cache = Hash.new { |h,k| h[k] = {} }
 
       # { Package => Boolean }
-      @required = Set.new
+      @required = {}
     end
 
     def add_assignment(assignment)
@@ -106,7 +105,7 @@ module PubGrub
       @assignments << assignment
       @assignments_by[package] << assignment
 
-      @required.add(package) if term.positive?
+      @required[package] = true if term.positive?
 
       if @terms.key?(package)
         old_term = @terms[package]

--- a/lib/pub_grub/term.rb
+++ b/lib/pub_grub/term.rb
@@ -1,5 +1,3 @@
-require 'forwardable'
-
 module PubGrub
   class Term
     attr_reader :package, :constraint, :positive

--- a/lib/pub_grub/version_solver.rb
+++ b/lib/pub_grub/version_solver.rb
@@ -16,7 +16,7 @@ module PubGrub
         h[k] = []
       end
 
-      @seen_incompatibilities = Set.new
+      @seen_incompatibilities = {}
 
       @solution = PartialSolution.new
 
@@ -136,7 +136,7 @@ module PubGrub
           logger.debug { "knew: #{incompatibility}" }
           next
         end
-        @seen_incompatibilities.add(incompatibility)
+        @seen_incompatibilities[incompatibility] = true
 
         add_incompatibility incompatibility
 

--- a/lib/pub_grub/version_solver.rb
+++ b/lib/pub_grub/version_solver.rb
@@ -5,10 +5,13 @@ require 'pub_grub/solve_failure'
 
 module PubGrub
   class VersionSolver
+    attr_reader :logger
     attr_reader :source
     attr_reader :solution
 
-    def initialize(source:, root: Package.root)
+    def initialize(source:, root: Package.root, logger: PubGrub.logger)
+      @logger = logger
+
       @source = source
 
       # { package => [incompatibility, ...]}
@@ -239,10 +242,6 @@ module PubGrub
         package = term.package
         @incompatibilities[package] << incompatibility
       end
-    end
-
-    def logger
-      PubGrub.logger
     end
   end
 end


### PR DESCRIPTION
As the fences close in on more and more of stdlib becoming default gems, it seems ideal for Gel to avoid them all where-ever possible. 

I'd generally consider that a "my problem" situation, but given PubGrub's potential use cases, it seems like that might not be a unique consideration amongst its downstreams.


The proposed changes here feel like they vary somewhat in potential controversy: dropping an unused require is fine, and the Set -> Hash change is tiny enough that's it's probably okay... but Logger is a bit more involved. Let me know if you'd prefer I pull that one out.