### PR TITLE
Ensure VersionRange#eql?(VersionUnion) works

### DIFF
--- a/lib/pub_grub/version_range.rb
+++ b/lib/pub_grub/version_range.rb
@@ -83,10 +83,14 @@ module PubGrub
     end
 
     def eql?(other)
-      min.eql?(other.min) &&
-        max.eql?(other.max) &&
-        include_min.eql?(other.include_min) &&
-        include_max.eql?(other.include_max)
+      if other.is_a?(VersionRange)
+        min.eql?(other.min) &&
+          max.eql?(other.max) &&
+          include_min.eql?(other.include_min) &&
+          include_max.eql?(other.include_max)
+      else
+        ranges.eql?(other.ranges)
+      end
     end
 
     def ranges

--- a/test/pub_grub/version_union_test.rb
+++ b/test/pub_grub/version_union_test.rb
@@ -52,6 +52,18 @@ module PubGrub
       assert_equal VersionRange.new(min: 2, max: 6), a
     end
 
+    def test_eql
+      a = union([
+        VersionRange.new(min: 1, max: 3),
+        VersionRange.new(min: 4, max: 7),
+      ])
+
+      assert_operator a, :eql?, a
+      refute_operator a.ranges.first, :eql?, a
+      refute_operator a, :eql?, a.ranges.first
+      assert_operator a, :eql?, union(a.ranges)
+    end
+
     def test_simple
       a = union([
         VersionRange.new(min: 1, max: 3),


### PR DESCRIPTION
This can come up during resolution, because `Constraint#range` can contain instances of either class, and then since 0ce5c9571bce11ddb99c55b4be1cb2e23004566b we end up in `Term#eql?` -> `Constraint#eql?` -> `range#eql?(other.range)`.

It's still super rare, because you need a `VersionUnion` for a particular package to `hash` to the same bucket as a `VersionRange` for that same package. I have seen it come up occasionally in Gel's suite -- likely because the huge union on each of the Rails dependencies has more chances to trip it -- and often enough that I stopped to investigate this time.