### PR TITLE
Make sure `VersionRange::Empty#hash` works

### DIFF
--- a/lib/pub_grub/version_range.rb
+++ b/lib/pub_grub/version_range.rb
@@ -23,6 +23,10 @@ module PubGrub
         other.empty?
       end
 
+      def hash
+        [].hash
+      end
+
       def intersects?(_)
         false
       end

--- a/test/pub_grub/version_range_test.rb
+++ b/test/pub_grub/version_range_test.rb
@@ -198,6 +198,8 @@ module PubGrub
 
       assert_equal VersionRange.any, empty.invert
       assert_equal empty, VersionRange.any.invert
+
+      assert empty.hash
     end
 
     def test_contiguous_to


### PR DESCRIPTION
The subclass does not respond to `#min` or `#max` defined, so if `#hash`
ends up being called, it results in a crash because the parent class
defines `#hash` using these attributes.

This can happen when checking whether an incompatibility has
been previously seen, if the incompatibility includes a
`VersionRange::Empty` term.

This commit fixes the issue by explicitly defining
`VersionRange::Empty#hash`.
