### PR TITLE
Use better next dependency selection strategy

### DIFF
--- a/lib/pub_grub/version_range.rb
+++ b/lib/pub_grub/version_range.rb
@@ -364,6 +364,12 @@ module PubGrub
       "#<#{self.class} #{to_s}>"
     end
 
+    def upper_invert
+      return self.class.empty unless max
+
+      VersionRange.new(min: max, include_min: !include_max)
+    end
+
     def invert
       return self.class.empty if any?
 

--- a/lib/pub_grub/version_solver.rb
+++ b/lib/pub_grub/version_solver.rb
@@ -23,8 +23,6 @@ module PubGrub
 
       @solution = PartialSolution.new
 
-      @package_depth = { root => 0 }
-
       add_incompatibility Incompatibility.new([
         Term.new(VersionConstraint.any(root), false)
       ], cause: :root)
@@ -110,9 +108,11 @@ module PubGrub
     def next_package_to_try
       solution.unsatisfied.min_by do |term|
         package = term.package
-        versions = source.versions_for(package, term.constraint.range.upper_invert)
+        range = term.constraint.range
+        matching_versions = source.versions_for(package, range)
+        higher_versions = source.versions_for(package, range.upper_invert)
 
-        [@package_depth[package], versions.count]
+        [matching_versions.count <= 1 ? 0 : 1, higher_versions.count]
       end.package
     end
 
@@ -145,12 +145,6 @@ module PubGrub
 
         conflict ||= incompatibility.terms.all? do |term|
           term.package == package || solution.satisfies?(term)
-        end
-
-        # Update depths of new packages
-        depth = @package_depth[package] + 1
-        incompatibility.terms.each do |term|
-          @package_depth[term.package] ||= depth
         end
       end
 

--- a/lib/pub_grub/version_solver.rb
+++ b/lib/pub_grub/version_solver.rb
@@ -110,7 +110,7 @@ module PubGrub
     def next_package_to_try
       solution.unsatisfied.min_by do |term|
         package = term.package
-        versions = source.versions_for(package, term.constraint.range)
+        versions = source.versions_for(package, term.constraint.range.upper_invert)
 
         [@package_depth[package], versions.count]
       end.package

--- a/lib/pub_grub/version_union.rb
+++ b/lib/pub_grub/version_union.rb
@@ -129,6 +129,10 @@ module PubGrub
       VersionUnion.union(new_ranges, normalize: false)
     end
 
+    def upper_invert
+      ranges.last.upper_invert
+    end
+
     def invert
       ranges.map(&:invert).inject(:intersect)
     end


### PR DESCRIPTION
While working on migrating Bundler to use PubGrub, I'm noticing several cases where, while PubGrub resolves correctly, its result is clearly inferior to current Bundler's result and it's also slower.

Further investigation pointed to the decision making phase, where Bundler is being smarter and choosing better dependencies that led into finding a solution earlier. I found that PubGrub's documentation in dart already acknowledges that there's room for improvement here. From https://github.com/dart-lang/pub/blob/master/doc/solver.md#decision-making:

> Pub chooses the latest matching version of the package with the fewest versions that match the outstanding constraint. This tends to find conflicts earlier if any exist, since these packages will run out of versions to try more quickly. But there’s likely room for improvement in these heuristics.

Looking at PubGrub results, I noticed the problem was that the solution includes ancient versions of gems nobdoy wants a fresh bundle to resolve to.

For example, one realworld case was resolving to Rails 2.3.2 (in exchange for choosing the recent 3.0.0 release of rack), while Bundler properly sticks to modern Rails and to the previous 2.2.4 release of Rack. This real example can be checked here: https://github.com/soulcutter/resolution_explosion.

On another realworld case, PubGrub was taking about 20 seconds to find a solution (reeeeeally slow for PubGrub standards) before finding a solution involving... Rails 0.9.5, after 49 attempts. This one can be checked here: https://github.com/duckinator/rubygems-4539-testcase.

My diagnosis of the issue was that the older a dependency is, the less priority it should get in the decision making phase. And my criteria to decide how old a dependency is is how many versions of the dependency are higher than the dependency range upper bound.

With this criteria, these realworld cases resolve instantly and with the same result as Molinillo.

I didn't add tests yet because I wanted to get some feedback on this idea first.