### PR TITLE
Respect root notion of custom package classes

### DIFF
--- a/lib/pub_grub/incompatibility.rb
+++ b/lib/pub_grub/incompatibility.rb
@@ -32,7 +32,7 @@ module PubGrub
     end
 
     def failure?
-      terms.empty? || (terms.length == 1 && terms[0].package == Package.root && terms[0].positive?)
+      terms.empty? || (terms.length == 1 && Package.root?(terms[0].package) && terms[0].positive?)
     end
 
     def conflict?
@@ -125,7 +125,7 @@ module PubGrub
 
       if terms.length != 1 && ConflictCause === cause
         terms = terms.reject do |term|
-          term.positive? && term.package == Package.root
+          term.positive? && Package.root?(term.package)
         end
       end
 

--- a/lib/pub_grub/package.rb
+++ b/lib/pub_grub/package.rb
@@ -28,6 +28,14 @@ module PubGrub
       ROOT_VERSION
     end
 
+    def self.root?(package)
+      if package.respond_to?(:root?)
+        package.root?
+      else
+        package == root
+      end
+    end
+
     def to_s
       name.to_s
     end

--- a/lib/pub_grub/version_constraint.rb
+++ b/lib/pub_grub/version_constraint.rb
@@ -91,7 +91,7 @@ module PubGrub
     end
 
     def to_s(allow_every: false)
-      if package == Package.root
+      if Package.root?(package)
         "root"
       elsif allow_every && any?
         "every version of #{package}"

--- a/lib/pub_grub/version_constraint.rb
+++ b/lib/pub_grub/version_constraint.rb
@@ -92,7 +92,7 @@ module PubGrub
 
     def to_s(allow_every: false)
       if Package.root?(package)
-        "root"
+        package.to_s
       elsif allow_every && any?
         "every version of #{package}"
       else

--- a/lib/pub_grub/version_solver.rb
+++ b/lib/pub_grub/version_solver.rb
@@ -44,7 +44,7 @@ module PubGrub
       if solved?
         logger.info { "Solution found after #{solution.attempted_solutions} attempts:" }
         solution.decisions.each do |package, version|
-          next if package == Package.root
+          next if Package.root?(package)
           logger.info { "* #{package} #{version}" }
         end
 

--- a/test/pub_grub/package_test.rb
+++ b/test/pub_grub/package_test.rb
@@ -17,6 +17,18 @@ module PubGrub
 
       assert_kind_of Package, package
       assert_equal "pkg", package.name
+      refute Package.root?(package)
+    end
+
+    def test_custom_package
+      package_class = Struct.new(:name, :root) do
+        def root?
+          root == true
+        end
+      end
+
+      refute Package.root?(package_class.new("pkg", false))
+      assert Package.root?(package_class.new("pkg", true))
     end
   end
 end


### PR DESCRIPTION
If a pub grub user implements its own package class, it may have its own notion of root package. As a matter of fact, PubGrub's solver can receive a custom root package (falling back to its own internal `Package.root`).

However, when internally checking whether a package is the root package, PubGrub was always hardcoding the comparison to its own `Package.root`.

This PR tries to give more flexibility here by allowing custom package classes to define a `#root?` method, and respect that during solving, while trying to keep backwards compatibility with existing package classes that don't implement this.