### PR TITLE
Expose `SolveFailure` incompatibility

### DIFF
--- a/lib/pub_grub/solve_failure.rb
+++ b/lib/pub_grub/solve_failure.rb
@@ -2,6 +2,8 @@ require_relative 'failure_writer'
 
 module PubGrub
   class SolveFailure < StandardError
+    attr_reader :incompatibility
+
     def initialize(incompatibility)
       @incompatibility = incompatibility
     end


### PR DESCRIPTION
In Bundler, we normally try resolution with as many locked gems as possible from the Gemfile.lock file, but if resolution fails in that "conservative mode", we automatically unlock any locked gems that cause conflicts and retry in a more "free mode". We do this by inspecting the initial solve failure and figuring out if any locked gems caused the conflicts.

Exposising SolveFailure's incompatibility is useful for this.