### PR TITLE
Allow customizing failure explanations

### DIFF
--- a/lib/pub_grub/basic_package_source.rb
+++ b/lib/pub_grub/basic_package_source.rb
@@ -128,6 +128,12 @@ module PubGrub
       end
     end
 
+    def no_versions_incompatibility_for(_package, unsatisfied_term)
+      cause = Incompatibility::NoVersions.new(unsatisfied_term)
+
+      Incompatibility.new([unsatisfied_term], cause: cause)
+    end
+
     def incompatibilities_for(package, version)
       package_deps = @cached_dependencies[package]
       sorted_versions = @sorted_versions[package]

--- a/lib/pub_grub/incompatibility.rb
+++ b/lib/pub_grub/incompatibility.rb
@@ -13,9 +13,10 @@ module PubGrub
 
     attr_reader :terms, :cause
 
-    def initialize(terms, cause:)
+    def initialize(terms, cause:, custom_explanation: nil)
       @cause = cause
       @terms = cleanup_terms(terms)
+      @custom_explanation = custom_explanation
 
       if cause == :dependency && @terms.length != 2
         raise ArgumentError, "a dependency Incompatibility must have exactly two terms. Got #{@terms.inspect}"
@@ -53,6 +54,8 @@ module PubGrub
     end
 
     def to_s
+      return @custom_explanation if @custom_explanation
+
       case cause
       when :root
         "(root dependency)"

--- a/lib/pub_grub/version_solver.rb
+++ b/lib/pub_grub/version_solver.rb
@@ -127,8 +127,7 @@ module PubGrub
       version = source.versions_for(package, unsatisfied_term.constraint.range).first
 
       if version.nil?
-        cause = Incompatibility::NoVersions.new(unsatisfied_term)
-        add_incompatibility Incompatibility.new([unsatisfied_term], cause: cause)
+        add_incompatibility source.no_versions_incompatibility_for(package, unsatisfied_term)
         return package
       end
 


### PR DESCRIPTION
In Bundler, even if PubGrub gives much better error messages, I still wanted to keep some parts of current resolution messages that look useful to me and I think added some extra clarify. For example, special messages for "meta-dependencies", like the Ruby version, or mention to Gemfile sources when versions cannot be found. So, some example of the new error messages would look like this:

```
Because every version of foo depends on requires-old-ruby >= 0
  and every version of requires-old-ruby depends on Ruby < 3.1.2,
  every version of foo requires Ruby < 3.1.2.
So, because Gemfile depends on foo >= 0
  and current Ruby version is = 3.1.2,
  version solving has failed.
```

or

```
Because the current Bundler version (2.4.0.dev) does not satisfy bundler = 0.9.1
  and Gemfile depends on bundler = 0.9.1,
  version solving has failed.
```

or

```
Because every version of depends_on_rack depends on rack >= 0
  and no versions in rubygems repository https://gem.repo2/ or installed locally satisfy rack >= 0,
  every version of depends_on_rack is forbidden.
So, because Gemfile depends on depends_on_rack >= 0,
  version solving has failed.
```

This PR allow more easily customizing the error messages like above.