### PR TITLE
Fix crash when dealing with circular requirements

### DIFF
--- a/lib/pub_grub/basic_package_source.rb
+++ b/lib/pub_grub/basic_package_source.rb
@@ -172,6 +172,11 @@ module PubGrub
           # no such package -> this version is invalid
         end
 
+        if package == dep_package
+          cause = PubGrub::Incompatibility::CircularDependency.new(dep_package, dep_constraint_name)
+          return [Incompatibility.new([Term.new(self_constraint, true)], cause: cause)]
+        end
+
         dep_constraint = parse_dependency(dep_package, dep_constraint_name)
         if !dep_constraint
           # falsey indicates this dependency was invalid

--- a/lib/pub_grub/incompatibility.rb
+++ b/lib/pub_grub/incompatibility.rb
@@ -8,6 +8,9 @@ module PubGrub
     InvalidDependency = Struct.new(:package, :constraint) do
     end
 
+    CircularDependency = Struct.new(:package, :constraint) do
+    end
+
     NoVersions = Struct.new(:constraint) do
     end
 
@@ -63,6 +66,8 @@ module PubGrub
         "#{terms[0].to_s(allow_every: true)} depends on #{terms[1].invert}"
       when PubGrub::Incompatibility::InvalidDependency
         "#{terms[0].to_s(allow_every: true)} depends on unknown package #{cause.package}"
+      when PubGrub::Incompatibility::CircularDependency
+        "#{terms[0].to_s(allow_every: true)} depends on itself"
       when PubGrub::Incompatibility::NoVersions
         "no versions satisfy #{cause.constraint}"
       when PubGrub::Incompatibility::ConflictCause

--- a/test/pub_grub/version_solver_test.rb
+++ b/test/pub_grub/version_solver_test.rb
@@ -393,5 +393,24 @@ Because rails < 7.0.4 depends on railties = 7.0.3.1
 Thus, version solving has failed.
 ERR
     end
+
+    def test_circular_dependency
+      source = StaticPackageSource.new do |s|
+        s.root deps: { 'circular-dependency' => '>= 0' }
+
+        s.add 'circular-dependency', '0.0.1', deps: { 'circular-dependency' => '>= 0' }
+      end
+
+      solver = VersionSolver.new(source: source)
+
+      ex = assert_raises PubGrub::SolveFailure do
+        solver.solve
+      end
+      assert_equal <<ERR.strip,  ex.explanation.strip
+Because every version of circular-dependency depends on itself
+  and root depends on circular-dependency >= 0,
+  version solving has failed.
+ERR
+    end
   end
 end


### PR DESCRIPTION
When dealing with a situation like [this one](https://github.com/dependabot-fixtures/rubygems-circular-dependency), PubGrub would previously raise an unexpected error like the following:

```
...................................F

Failure:
PubGrub::VersionSolverTest#test_circular_dependency [/Users/deivid/Code/jhawthorn/pub_grub/test/pub_grub/version_solver_test.rb:372]:
[PubGrub::SolveFailure] exception expected, not
Class: <ArgumentError>
Message: <"a dependency Incompatibility must have exactly two terms. Got [#<PubGrub::Term circular-dependency < 0>]">
---Backtrace---
/Users/deivid/Code/jhawthorn/pub_grub/lib/pub_grub/incompatibility.rb:22:in `initialize'
/Users/deivid/Code/jhawthorn/pub_grub/lib/pub_grub/basic_package_source.rb:185:in `new'
/Users/deivid/Code/jhawthorn/pub_grub/lib/pub_grub/basic_package_source.rb:185:in `block in incompatibilities_for'
/Users/deivid/Code/jhawthorn/pub_grub/lib/pub_grub/basic_package_source.rb:140:in `each'
/Users/deivid/Code/jhawthorn/pub_grub/lib/pub_grub/basic_package_source.rb:140:in `map'
/Users/deivid/Code/jhawthorn/pub_grub/lib/pub_grub/basic_package_source.rb:140:in `incompatibilities_for'
/Users/deivid/Code/jhawthorn/pub_grub/lib/pub_grub/version_solver.rb:136:in `choose_package_version'
/Users/deivid/Code/jhawthorn/pub_grub/lib/pub_grub/version_solver.rb:41:in `work'
/Users/deivid/Code/jhawthorn/pub_grub/lib/pub_grub/version_solver.rb:58:in `solve'
/Users/deivid/Code/jhawthorn/pub_grub/test/pub_grub/version_solver_test.rb:373:in `block in test_circular_dependency'
---------------
```

Now it raises a more PubGrub-like user friendly error:

```
Because every version of circular-dependency depends on itself
  and root depends on circular-dependency >= 0,
  version solving has failed.
```
