### PR TITLE
Fix crash when error explanation includes empty ranges and version unions

### DIFF
--- a/lib/pub_grub/version_union.rb
+++ b/lib/pub_grub/version_union.rb
@@ -77,7 +77,7 @@ module PubGrub
           return true
         end
 
-        if !my_range.max || (other_range.max && other_range.max < my_range.max)
+        if !my_range.max || other_range.empty? || (other_range.max && other_range.max < my_range.max)
           other_range = other_ranges.shift
         else
           my_range = my_ranges.shift
@@ -119,7 +119,7 @@ module PubGrub
       while my_range && other_range
         new_ranges << my_range.intersect(other_range)
 
-        if !my_range.max || (other_range.max && other_range.max < my_range.max)
+        if !my_range.max || other_range.empty? || (other_range.max && other_range.max < my_range.max)
           other_range = other_ranges.shift
         else
           my_range = my_ranges.shift

--- a/test/pub_grub/version_union_test.rb
+++ b/test/pub_grub/version_union_test.rb
@@ -212,6 +212,20 @@ module PubGrub
       assert_equal expected, b.intersect(a)
     end
 
+    def test_intersect_empty
+      a = union([
+        VersionRange.new(min: 2, max: 3),
+        VersionRange.new(min: 4, max: 5),
+        VersionRange.new(min: 6, max: 8)
+      ])
+
+      b = VersionRange.empty
+
+      refute a.intersects?(b)
+
+      assert_equal VersionRange.empty, a.intersect(b)
+    end
+
     def test_allows_all?
       a = union([
         VersionRange.new(min: 2, max: 3),


### PR DESCRIPTION
Previously this would result in an error like

```
  1) Error:
PubGrub::VersionUnionTest#test_intersect_empty:
NoMethodError: undefined method `max' for #<PubGrub::VersionRange::Empty (no versions)>

        if !my_range.max || (other_range.max && other_range.max < my_range.max)
                                        ^^^^
    /Users/deivid/Code/jhawthorn/pub_grub/lib/pub_grub/version_union.rb:122:in `intersect'
    /Users/deivid/Code/jhawthorn/pub_grub/test/pub_grub/version_union_test.rb:224:in `test_intersect_empty'
```