### PR TITLE
Add a proper constraint equality

### DIFF
--- a/lib/pub_grub/version_constraint.rb
+++ b/lib/pub_grub/version_constraint.rb
@@ -15,6 +15,11 @@ module PubGrub
       package.hash ^ range.hash
     end
 
+    def ==(other)
+      package == other.package &&
+        range == other.range
+    end
+
     def eql?(other)
       package.eql?(other.package) &&
         range.eql?(other.range)

--- a/test/pub_grub/version_constraint_test.rb
+++ b/test/pub_grub/version_constraint_test.rb
@@ -10,6 +10,13 @@ module PubGrub
       PubGrub::RubyGems.parse_constraint(package, constraint)
     end
 
+    def test_equality
+      a = parse(@package, "~> 1.0")
+      b = parse(@package, "~> 1.0")
+
+      assert_equal a, b
+    end
+
     def test_empty_restriction
       constraint = VersionConstraint.any(@package)
 


### PR DESCRIPTION
This is not a problem in PubGrub itself, but it should make custom integrations with PubGrub better.

While debugging some issues in Bundler, I noticed from pub_grub's debug logs, that incompatibility constraints didn't seem to be merged correctly when across versions with the same dependencies. Since I was seeing output like this:

```
derived: not autobuild >= 1.10.0.b4, < 1.10.0.rc1
derived: not autobuild >= 1.10.0.rc1, < 1.10.0.rc2
derived: not autobuild >= 1.10.0.rc2, < 1.10.0.rc3
derived: not autobuild >= 1.10.0.rc3, < 1.10.0.rc4
derived: not autobuild >= 1.10.0.rc4, < 1.10.0.rc5
derived: not autobuild >= 1.10.0.rc5, < 1.10.0.rc6
derived: not autobuild >= 1.10.0.rc6, < 1.10.0.rc7
derived: not autobuild >= 1.10.0.rc7, < 1.10.0.rc8
derived: not autobuild >= 1.10.0.rc8, < 1.10.0.rc9
```

Ended up noticing that in our custom package class in Bundler, which does not inherit from `BasicPackageSource` in pub_grub, we're [comparing `VersionConstraints`](https://github.com/rubygems/rubygems/blob/3a27b699471db4ec8094014b91e0720e5f2a4827/bundler/lib/bundler/resolver.rb#L180) instead of [comparing strings](https://github.com/jhawthorn/pub_grub/blob/1d766d74665991817c770b8fc54873b4c197c094/lib/pub_grub/basic_package_source.rb#L145) like `BasicPackageSource`.

I could've probably fixed this in Bundler, but I think implementing a proper equality here is good thing.

This change speeds up resolution on [this realworld gemfile](https://github.com/rubygems/rubygems/blob/3a27b699471db4ec8094014b91e0720e5f2a4827/bundler/spec/realworld/edgecases_spec.rb#L362-L514) from the Nix project from ~7 minutes to ~30 seconds on my laptop.