### PR TITLE
Use `to_s` representation of min and max when displaying ranges and unions

### DIFF
--- a/lib/pub_grub/version_range.rb
+++ b/lib/pub_grub/version_range.rb
@@ -397,7 +397,7 @@ module PubGrub
 
     def constraints
       return ["any"] if any?
-      return ["= #{min}"] if min == max
+      return ["= #{min}"] if min.to_s == max.to_s
 
       c = []
       c << "#{include_min ? ">=" : ">"} #{min}" if min

--- a/lib/pub_grub/version_union.rb
+++ b/lib/pub_grub/version_union.rb
@@ -148,7 +148,7 @@ module PubGrub
       while !ranges.empty?
         ne = []
         range = ranges.shift
-        while !ranges.empty? && ranges[0].min == range.max
+        while !ranges.empty? && ranges[0].min.to_s == range.max.to_s
           ne << range.max
           range = range.span(ranges.shift)
         end

--- a/test/pub_grub/version_range_test.rb
+++ b/test/pub_grub/version_range_test.rb
@@ -349,6 +349,28 @@ module PubGrub
       assert_equal b, b
     end
 
+    def test_to_s_with_custom_versions
+      version = Class.new do
+        attr_reader :version, :platform
+
+        def initialize(version, platform = "ruby")
+          @version = version
+          @platform = platform
+        end
+
+        def ==(other)
+          @version == other.version && @platform == other.platform
+        end
+
+        def to_s
+          version.to_s
+        end
+      end
+
+      a = VersionRange.new(min: version.new(2), max: version.new(2, "linux"))
+      assert_equal "= 2", a.to_s
+    end
+
     def test_contiguous_intersect
       a = VersionRange.new(min: nil, max: 2)
       b = VersionRange.new(min: 2, max: nil)

--- a/test/pub_grub/version_union_test.rb
+++ b/test/pub_grub/version_union_test.rb
@@ -135,6 +135,41 @@ module PubGrub
       assert_equal "> 1, < 8, != 3, != 5", complex.to_s
     end
 
+    def test_not_equal_with_custom_version
+      version = Class.new do
+        include Comparable
+
+        attr_reader :version, :platform
+
+        def initialize(version, platform = "ruby")
+          @version = version
+          @platform = platform
+        end
+
+        def ==(other)
+          @version == other.version && @platform == other.platform
+        end
+
+        def <=>(other)
+          sort_obj <=> other.sort_obj
+        end
+
+        def sort_obj
+          [@version, @platform == "ruby" ? -1 : 1]
+        end
+
+        def to_s
+          version.to_s
+        end
+      end
+
+      a = union([
+        VersionRange.new(max: version.new(2)),
+        VersionRange.new(min: version.new(2, "linux"))
+      ])
+      assert_equal "!= 2", a.to_s
+    end
+
     def test_single_overlap
       a = union([
         VersionRange.new(min: 0, max: 1),


### PR DESCRIPTION
In Bundler, we consider "1.12.5" and "1.12.5-x86_64-linux" different for resolution purposes, but equal when representing versions in error messages and so on.

Using strict min and max equality for range string representation leads to same weird ranges reading like "< 1.12.5, > 1.12.5".

It seems best to use the equality of string representations of mix and max to decide whether to display "=" or "<, >" for representing ranges.

Similarly for version unions.