### PR TITLE
Improve handling of self-referencing dependencies

### DIFF
--- a/lib/pub_grub/basic_package_source.rb
+++ b/lib/pub_grub/basic_package_source.rb
@@ -172,11 +172,6 @@ module PubGrub
           # no such package -> this version is invalid
         end
 
-        if package == dep_package
-          cause = PubGrub::Incompatibility::CircularDependency.new(dep_package, dep_constraint_name)
-          return [Incompatibility.new([Term.new(self_constraint, true)], cause: cause)]
-        end
-
         dep_constraint = parse_dependency(dep_package, dep_constraint_name)
         if !dep_constraint
           # falsey indicates this dependency was invalid

--- a/lib/pub_grub/incompatibility.rb
+++ b/lib/pub_grub/incompatibility.rb
@@ -8,9 +8,6 @@ module PubGrub
     InvalidDependency = Struct.new(:package, :constraint) do
     end
 
-    CircularDependency = Struct.new(:package, :constraint) do
-    end
-
     NoVersions = Struct.new(:constraint) do
     end
 
@@ -66,8 +63,6 @@ module PubGrub
         "#{terms[0].to_s(allow_every: true)} depends on #{terms[1].invert}"
       when PubGrub::Incompatibility::InvalidDependency
         "#{terms[0].to_s(allow_every: true)} depends on unknown package #{cause.package}"
-      when PubGrub::Incompatibility::CircularDependency
-        "#{terms[0].to_s(allow_every: true)} depends on itself"
       when PubGrub::Incompatibility::NoVersions
         "no versions satisfy #{cause.constraint}"
       when PubGrub::Incompatibility::ConflictCause

--- a/lib/pub_grub/static_package_source.rb
+++ b/lib/pub_grub/static_package_source.rb
@@ -19,7 +19,14 @@ module PubGrub
         version = Gem::Version.new(version)
         @packages[name] ||= {}
         raise ArgumentError, "#{name} #{version} declared twice" if @packages[name].key?(version)
-        @packages[name][version] = deps
+        @packages[name][version] = clean_deps(name, version, deps)
+      end
+
+      private
+
+      # Exclude redundant self-referencing dependencies
+      def clean_deps(name, version, deps)
+        deps.reject {|dep_name, req| name == dep_name && PubGrub::RubyGems.parse_range(req).include?(version) }
       end
     end
 

--- a/test/pub_grub/version_solver_test.rb
+++ b/test/pub_grub/version_solver_test.rb
@@ -402,15 +402,11 @@ ERR
       end
 
       solver = VersionSolver.new(source: source)
+      result = solver.solve
 
-      ex = assert_raises PubGrub::SolveFailure do
-        solver.solve
-      end
-      assert_equal <<ERR.strip,  ex.explanation.strip
-Because every version of circular-dependency depends on itself
-  and root depends on circular-dependency >= 0,
-  version solving has failed.
-ERR
+      assert_solution source, result, {
+        'circular-dependency' => '0.0.1'
+      }
     end
   end
 end


### PR DESCRIPTION
The [previous approach](https://github.com/jhawthorn/pub_grub/pull/19) did not really work great in the realworld. See https://github.com/rubygems/rubygems/issues/6328.

 I think it's simpler to remove these self-referencing redundant dependencies in the package source, before resolution.

