### PR TITLE
Detect infinite loops when resolving conflicts

### DIFF
--- a/lib/pub_grub/version_solver.rb
+++ b/lib/pub_grub/version_solver.rb
@@ -162,7 +162,7 @@ module PubGrub
     def resolve_conflict(incompatibility)
       logger.info { "conflict: #{incompatibility}" }
 
-      new_incompatibility = false
+      new_incompatibility = nil
 
       while !incompatibility.failure?
         most_recent_term = nil
@@ -204,7 +204,7 @@ module PubGrub
           solution.backtrack(previous_level)
 
           if new_incompatibility
-            add_incompatibility(incompatibility)
+            add_incompatibility(new_incompatibility)
           end
 
           return incompatibility
@@ -219,9 +219,14 @@ module PubGrub
           new_terms << difference.invert
         end
 
-        incompatibility = Incompatibility.new(new_terms, cause: Incompatibility::ConflictCause.new(incompatibility, most_recent_satisfier.cause))
+        new_incompatibility = Incompatibility.new(new_terms, cause: Incompatibility::ConflictCause.new(incompatibility, most_recent_satisfier.cause))
 
-        new_incompatibility = true
+        if incompatibility.to_s == new_incompatibility.to_s
+          logger.info { "!! failed to resolve conflicts, this shouldn't have happened" }
+          break
+        end
+
+        incompatibility = new_incompatibility
 
         partially = difference ? " partially" : ""
         logger.info { "! #{most_recent_term} is#{partially} satisfied by #{most_recent_satisfier.term}" }


### PR DESCRIPTION
We've been getting several reports about Bundler hanging infinitely when resolving.

I believe this is a bug in pub_grub, but while I isolate a test case and fix, I think it's an improvement already to detect infinite loops when resolving conflicts and bail out.

We can remove this once the culprit is properly addressed.