### PR TITLE
Added explicitly require for PubGrub::RubyGems

### DIFF
--- a/lib/pub_grub/static_package_source.rb
+++ b/lib/pub_grub/static_package_source.rb
@@ -1,4 +1,5 @@
 require_relative 'package'
+require_relative 'rubygems'
 require_relative 'version_constraint'
 require_relative 'incompatibility'
 require_relative 'basic_package_source'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,6 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require 'minitest'
 require "pub_grub"
-require "pub_grub/rubygems"
 
 PubGrub.logger.level = Logger::DEBUG if ENV['DEBUG']
 


### PR DESCRIPTION
👋 Hi, Thank you for maintaining `pub_grub`.

I got `NameError` with sample code like:

```
$ cat -p sample1.rb
require "pub_grub"

source = PubGrub::StaticPackageSource.new do |s|
  s.add 'foo', '2.0.0', deps: { 'bar' => '1.0.0' }
  s.add 'foo', '1.0.0'
  
  s.add 'bar', '1.0.0', deps: { 'foo' => '1.0.0' }
  
  s.root deps: { 'foo' => '>= 1.0.0' }
end

solver = PubGrub::VersionSolver.new(source: source)
result = solver.solve
$ ruby sample1.rb
/Users/hsbt/.local/share/gem/gems/pub_grub-0.5.0/lib/pub_grub/static_package_source.rb:50:in `parse_dependency': uninitialized constant PubGrub::RubyGems (NameError)

      PubGrub::RubyGems.parse_constraint(package, dependency)
             ^^^^^^^^^^
```

I'm not sure why `pub_grub/rubygems.rb` is not required by `lib/pub_grub/static_package_source.rb`. But `PubGrub::StaticPackageSource` always refer `PubGrub::RubyGems`. We should load it explicitly.

