### PR TITLE
Fix issue in BasicPackageSource that prevents resolution from succeeding sometimes

### DIFF
--- a/lib/pub_grub/basic_package_source.rb
+++ b/lib/pub_grub/basic_package_source.rb
@@ -164,7 +164,7 @@ module PubGrub
             sorted_versions[high]
           end
 
-        range = VersionRange.new(min: low, max: high, include_min: true)
+        range = VersionRange.new(min: low, max: high, include_min: !low.nil?)
 
         self_constraint = VersionConstraint.new(package, range: range)
 

--- a/lib/pub_grub/version_range.rb
+++ b/lib/pub_grub/version_range.rb
@@ -76,6 +76,9 @@ module PubGrub
     end
 
     def initialize(min: nil, max: nil, include_min: false, include_max: false, name: nil)
+      raise ArgumentError, "Ranges without a lower bound cannot have include_min == true" if !min && include_min == true
+      raise ArgumentError, "Ranges without an upper bound cannot have include_max == true" if !max && include_max == true
+
       @min = min
       @max = max
       @include_min = include_min
@@ -375,15 +378,15 @@ module PubGrub
     def invert
       return self.class.empty if any?
 
-      low = VersionRange.new(max: min, include_max: !include_min)
-      high = VersionRange.new(min: max, include_min: !include_max)
+      low = -> { VersionRange.new(max: min, include_max: !include_min) }
+      high = -> { VersionRange.new(min: max, include_min: !include_max) }
 
       if !min
-        high
+        high.call
       elsif !max
-        low
+        low.call
       else
-        low.union(high)
+        low.call.union(high.call)
       end
     end
 

--- a/test/pub_grub/version_range_test.rb
+++ b/test/pub_grub/version_range_test.rb
@@ -31,6 +31,9 @@ module PubGrub
       assert_includes range, 6
     end
 
+    def only_lower_ill_defined
+      assert_raise(ArgumentError) { VersionRange.new(min: 5, include_max: true) }
+    end
 
     # Only upper
 
@@ -54,6 +57,9 @@ module PubGrub
       refute_includes range, 8
     end
 
+    def only_upper_ill_defined
+      assert_raise(ArgumentError) { VersionRange.new(max: 7, include_min: true) }
+    end
 
     # Both
 


### PR DESCRIPTION
The current implementation of `BasicPackageSource` was sometimes creating version ranges with `min == nil`, and `include_min == true`. These are weird, and although they generally work fine, they did cause the current implementation of `VersionRange#contiguous_to?` to not work fine, and as a result version solving to fail sometimes.

Fix is https://github.com/jhawthorn/pub_grub/commit/548456352087f09354809d54aea489351bb88fd5. That brings all molinillo integration specs back to green, and fixes the issue reported in #30.

Although this is not really a resolver issue, but an issue with a specific package source, Bundler inherited this bug because its package source was based on `BasicPackageSource`.

In bd1952144bc4d09063578ce92eef2e864a5a3c9e, I also started preventing these weird ranges from being created to make this kind of issue easier to detect in the future.

Fixes #30.

This is based on top of #34, just to get CI green.