### PR TITLE
Change `VersionRange#contiguous_to?` to deal better with "strange version ranges"

### DIFF
--- a/lib/pub_grub/version_range.rb
+++ b/lib/pub_grub/version_range.rb
@@ -314,10 +314,19 @@ module PubGrub
 
     def contiguous_to?(other)
       return false if other.empty?
+      return true if any?
 
-      intersects?(other) ||
-        (min == other.max && (include_min || other.include_max)) ||
-        (max == other.min && (include_max || other.include_min))
+      intersects?(other) || contiguous_below?(other) || contiguous_above?(other)
+    end
+
+    def contiguous_below?(other)
+      return false if !max || !other.min
+
+      max == other.min && (include_max || other.include_min)
+    end
+
+    def contiguous_above?(other)
+      other.contiguous_below?(self)
     end
 
     def allows_all?(other)


### PR DESCRIPTION
I found the culprit of #30 to be that sometimes BasicPackageSource creates version ranges with `min == nil` and `include_min == true` and `VersionRange#contiguous_to?` does not deal with this kind of range well, making pub grub create incorrect version unions.

I think the better fix for this #35, but this alternative implementation of `VersionRange#contiguous_to?` does not suffer from the issue and handles these strange ranges in a better way. Specific commit implementing this is 52fc70c0f530105af64e41275d43ad5448692e91.

Also built on top of #34 for green CI.

Also fixes #30.