### PR TITLE
Call `PartialSolution#unsatisfied` 6x less

### DIFF
--- a/lib/pub_grub/version_solver.rb
+++ b/lib/pub_grub/version_solver.rb
@@ -36,26 +36,25 @@ module PubGrub
 
     # Returns true if there is more work to be done, false otherwise
     def work
-      return false if solved?
-
-      next_package = choose_package_version
-      propagate(next_package)
-
-      if solved?
+      unsatisfied_terms = solution.unsatisfied
+      if unsatisfied_terms.empty?
         logger.info { "Solution found after #{solution.attempted_solutions} attempts:" }
         solution.decisions.each do |package, version|
           next if Package.root?(package)
           logger.info { "* #{package} #{version}" }
         end
 
-        false
-      else
-        true
+        return false
       end
+
+      next_package = choose_package_version_from(unsatisfied_terms)
+      propagate(next_package)
+
+      true
     end
 
     def solve
-      work until solved?
+      while work; end
 
       solution.decisions
     end
@@ -105,25 +104,21 @@ module PubGrub
       unsatisfied.package
     end
 
-    def next_package_to_try
-      solution.unsatisfied.min_by do |term|
+    def next_term_to_try_from(unsatisfied_terms)
+      unsatisfied_terms.min_by do |term|
         package = term.package
         range = term.constraint.range
         matching_versions = source.versions_for(package, range)
         higher_versions = source.versions_for(package, range.upper_invert)
 
         [matching_versions.count <= 1 ? 0 : 1, higher_versions.count]
-      end.package
+      end
     end
 
-    def choose_package_version
-      if solution.unsatisfied.empty?
-        logger.info "No packages unsatisfied. Solving complete!"
-        return nil
-      end
+    def choose_package_version_from(unsatisfied_terms)
+      unsatisfied_term = next_term_to_try_from(unsatisfied_terms)
+      package = unsatisfied_term.package
 
-      package = next_package_to_try
-      unsatisfied_term = solution.unsatisfied.find { |t| t.package == package }
       version = source.versions_for(package, unsatisfied_term.constraint.range).first
       logger.debug { "attempting #{package} #{version}" }
 


### PR DESCRIPTION
Previously, `#unsatisfied` was called 6 times per `#work` iteration:
- in `#solve` to determine whether to call `#work` again
- at the beginning of `#work` to early return
- at the beginning of `#choose_package_version` to early return
- a second time in `#choose_package_version` just to find the term that matches the package returned by `#next_package_to_try`
- in `#next_package_to_try`
- at the end of `#work` to get return value

In a profile of a large app I work on, `bundle update` is spending:
- 8.8% of time in `Hash#key?` due to `#unsatisfied`
- 5.5% of time in `#unsatisfied` itself
- 3.1% of time in `Bundler::Resolver::Package#hash` due to `#unsatisfied`
- 1.9% of time in `String#hash` due to `#unsatisfied`
- 1.4% of time in `Array#reject` due to `#unsatisfied`
- 0.7% of time in `Array#map` due to `#unsatisfied`
- 21.4% in total

This commit replaces the 6 calls to `#unsatisfied` with a single call that then gets passed through the other methods. Based on the profile, this should speedup `bundle update` in my app by ~18%.