### PR TITLE
Optimize `#next_package_to_try` by not sorting

### DIFF
--- a/lib/pub_grub/basic_package_source.rb
+++ b/lib/pub_grub/basic_package_source.rb
@@ -116,8 +116,12 @@ module PubGrub
       end
     end
 
+    def sorted_versions_for(package, range=VersionRange.any)
+      range.select_versions(@sorted_versions[package])
+    end
+
     def versions_for(package, range=VersionRange.any)
-      versions = range.select_versions(@sorted_versions[package])
+      versions = sorted_versions_for(package, range)
 
       # Conditional avoids (among other things) calling
       # sort_versions_by_preferred with the root package

--- a/lib/pub_grub/version_solver.rb
+++ b/lib/pub_grub/version_solver.rb
@@ -109,8 +109,8 @@ module PubGrub
       solution.unsatisfied.min_by do |term|
         package = term.package
         range = term.constraint.range
-        matching_versions = source.versions_for(package, range)
-        higher_versions = source.versions_for(package, range.upper_invert)
+        matching_versions = source.sorted_versions_for(package, range)
+        higher_versions = source.sorted_versions_for(package, range.upper_invert)
 
         [matching_versions.count <= 1 ? 0 : 1, higher_versions.count]
       end.package


### PR DESCRIPTION
A large app I work on was taking around a minute to `bundle update`, so I profiled it and found that `#sort_versions_by_preferred` was a large hotspot (~30% of total runtime).

I initially assumed that these calls must be inside `#choose_package_version`, where the sorting of `#versions_for` is important because a specific package version is picked. However, the 30% of runtime inside `#versions_for` was actually only the calls made inside `#next_package_to_try` (where the sorting is not used!).

This commit extracts `#sorted_versions_for`, which only fetches the pre-sorted versions that match the range but does not perform additional sorting afterwards. This prevents the costly sorts that are inevitably discarded.

Also note that Bundler has similarly extracted the same method, but named `select_sorted_versions`.