### PR TITLE
Extract Strategy for selecting next package and version preferencing

### DIFF
--- a/lib/pub_grub/basic_package_source.rb
+++ b/lib/pub_grub/basic_package_source.rb
@@ -79,29 +79,17 @@ module PubGrub
       dependencies_for(@root_package, @root_version)
     end
 
-    # Override me (maybe)
-    #
-    # If not overridden, the order returned by all_versions_for will be used
-    #
-    # Returns: Array of versions in preferred order
-    def sort_versions_by_preferred(package, sorted_versions)
-      indexes = @version_indexes[package]
-      sorted_versions.sort_by { |version| indexes[version] }
-    end
-
     def initialize
       @root_package = Package.root
       @root_version = Package.root_version
 
-      @cached_versions = Hash.new do |h,k|
+      @sorted_versions = Hash.new do |h,k|
         if k == @root_package
           h[k] = [@root_version]
         else
-          h[k] = all_versions_for(k)
+          h[k] = all_versions_for(k).sort
         end
       end
-      @sorted_versions = Hash.new { |h,k| h[k] = @cached_versions[k].sort }
-      @version_indexes = Hash.new { |h,k| h[k] = @cached_versions[k].each.with_index.to_h }
 
       @cached_dependencies = Hash.new do |packages, package|
         if package == @root_package
@@ -117,15 +105,7 @@ module PubGrub
     end
 
     def versions_for(package, range=VersionRange.any)
-      versions = range.select_versions(@sorted_versions[package])
-
-      # Conditional avoids (among other things) calling
-      # sort_versions_by_preferred with the root package
-      if versions.size > 1
-        sort_versions_by_preferred(package, versions)
-      else
-        versions
-      end
+      range.select_versions(@sorted_versions[package])
     end
 
     def no_versions_incompatibility_for(_package, unsatisfied_term)

--- a/lib/pub_grub/strategy.rb
+++ b/lib/pub_grub/strategy.rb
@@ -2,17 +2,33 @@ module PubGrub
   class Strategy
     def initialize(source)
       @source = source
+
+      @root_package = Package.root
+      @root_version = Package.root_version
+
+      @version_indexes = Hash.new do |h,k|
+        if k == @root_package
+          h[k] = { @root_version => 0 }
+        else
+          h[k] = @source.all_versions_for(k).each.with_index.to_h
+        end
+      end
     end
 
     def next_package_and_version(unsatisfied)
       package, range = next_term_to_try_from(unsatisfied)
 
-      version = @source.versions_for(package, range).first
-
-      [package, version]
+      [package, most_preferred_version_of(package, range)]
     end
 
     private
+
+    def most_preferred_version_of(package, range)
+      versions = @source.versions_for(package, range)
+
+      indexes = @version_indexes[package]
+      versions.min_by { |version| indexes[version] }
+    end
 
     def next_term_to_try_from(unsatisfied)
       unsatisfied.min_by do |package, range|

--- a/lib/pub_grub/strategy.rb
+++ b/lib/pub_grub/strategy.rb
@@ -1,0 +1,26 @@
+module PubGrub
+  class Strategy
+    def initialize(source)
+      @source = source
+    end
+
+    def next_package_and_version(unsatisfied)
+      package, range = next_term_to_try_from(unsatisfied)
+
+      version = @source.versions_for(package, range).first
+
+      [package, version]
+    end
+
+    private
+
+    def next_term_to_try_from(unsatisfied)
+      unsatisfied.min_by do |package, range|
+        matching_versions = @source.versions_for(package, range)
+        higher_versions = @source.versions_for(package, range.upper_invert)
+
+        [matching_versions.count <= 1 ? 0 : 1, higher_versions.count]
+      end
+    end
+  end
+end

--- a/lib/pub_grub/version_solver.rb
+++ b/lib/pub_grub/version_solver.rb
@@ -2,17 +2,20 @@ require_relative 'partial_solution'
 require_relative 'term'
 require_relative 'incompatibility'
 require_relative 'solve_failure'
+require_relative 'strategy'
 
 module PubGrub
   class VersionSolver
     attr_reader :logger
     attr_reader :source
     attr_reader :solution
+    attr_reader :strategy
 
-    def initialize(source:, root: Package.root, logger: PubGrub.logger)
+    def initialize(source:, root: Package.root, strategy: Strategy.new(source), logger: PubGrub.logger)
       @logger = logger
 
       @source = source
+      @strategy = strategy
 
       # { package => [incompatibility, ...]}
       @incompatibilities = Hash.new do |h, k|
@@ -104,25 +107,15 @@ module PubGrub
       unsatisfied.package
     end
 
-    def next_term_to_try_from(unsatisfied_terms)
-      unsatisfied_terms.min_by do |term|
-        package = term.package
-        range = term.constraint.range
-        matching_versions = source.versions_for(package, range)
-        higher_versions = source.versions_for(package, range.upper_invert)
-
-        [matching_versions.count <= 1 ? 0 : 1, higher_versions.count]
-      end
-    end
-
     def choose_package_version_from(unsatisfied_terms)
-      unsatisfied_term = next_term_to_try_from(unsatisfied_terms)
-      package = unsatisfied_term.package
+      remaining = unsatisfied_terms.map { |t| [t.package, t.constraint.range] }.to_h
 
-      version = source.versions_for(package, unsatisfied_term.constraint.range).first
+      package, version = strategy.next_package_and_version(remaining)
+
       logger.debug { "attempting #{package} #{version}" }
 
       if version.nil?
+        unsatisfied_term = unsatisfied_terms.find { |t| t.package == package }
         add_incompatibility source.no_versions_incompatibility_for(package, unsatisfied_term)
         return package
       end


### PR DESCRIPTION
Closes #38 

[Extract Strategy for selecting next package](https://github.com/jhawthorn/pub_grub/commit/48b5a0f0308c173eb0d76250504d37d6b82cbb0e)

This doesn't change any behavior but it does establish the API that
strategies should implement (`#next_package_and_version`).

---

[Extract version preferencing to strategy class](https://github.com/jhawthorn/pub_grub/commit/d0d7b759e26c609669f4a0cca3d58591717604d2)

In my large application, ~30% of time during `bundle update` is spent
comparing package versions due to the sorting currently in
`#next_term_to_try_from`. Since the package selection approach used only
compares the version count, the sorting is actually unnecessary and can
be omitted.

This commit builds on the previous one by extending the strategy class
to implement version preferencing in addition to package selection. Now,
`#versions_for` can simply fetch the sorted versions for a package so
that sorting is only performed when necessary.

Additionally, sorting is replaced by `#min_by` (to avoid comparisons
completely) since only a single package is ever going to be selected.